### PR TITLE
rename register methods

### DIFF
--- a/counter_test.go
+++ b/counter_test.go
@@ -14,7 +14,7 @@ func TestInc(t *testing.T) {
 		# TYPE test_counter_inc counter
 	`
 	m := New(MetricsOpts{MustRegister: true})
-	m.RegisterCounter("test_counter_inc", []string{"this"})
+	m.NewCounter("test_counter_inc", []string{"this"})
 	c := m.getCounter("test_counter_inc")
 
 	m.CounterInc("test_counter_inc", Labels{"this": "one"})
@@ -33,7 +33,7 @@ func TestInc(t *testing.T) {
 
 func TestIncMismatchedLabels(t *testing.T) {
 	m := New(MetricsOpts{MustRegister: true})
-	m.RegisterCounter("test_counter_mismatch_inc", []string{"this", "that"})
+	m.NewCounter("test_counter_mismatch_inc", []string{"this", "that"})
 
 	assert.Equal(t, 0, testutil.CollectAndCount(m.mPanicRecovery))
 	assert.NotPanics(t, assert.PanicTestFunc(func() {
@@ -51,7 +51,7 @@ func TestAdd(t *testing.T) {
 		# TYPE test_counter_add counter
 	`
 	m := New(MetricsOpts{MustRegister: true})
-	m.RegisterCounter("test_counter_add", []string{"this"})
+	m.NewCounter("test_counter_add", []string{"this"})
 	c := m.getCounter("test_counter_add")
 
 	m.CounterAdd("test_counter_add", 2.0, Labels{"this": "one"})
@@ -70,7 +70,7 @@ func TestAdd(t *testing.T) {
 
 func TestAddMismatchedLabels(t *testing.T) {
 	m := New(MetricsOpts{MustRegister: true})
-	m.RegisterCounter("test_counter_mismatched_add", []string{"this", "that"})
+	m.NewCounter("test_counter_mismatched_add", []string{"this", "that"})
 
 	assert.Equal(t, 0, testutil.CollectAndCount(m.mPanicRecovery))
 	assert.NotPanics(t, assert.PanicTestFunc(func() {

--- a/examples/main.go
+++ b/examples/main.go
@@ -25,8 +25,8 @@ func main() {
 		Separator:    ':',
 	})
 
-	metrics.RegisterCounter("inc_counter", []string{"region"})
-	metrics.RegisterCounter("add_counter", []string{"region"})
+	metrics.NewCounter("inc_counter", []string{"region"})
+	metrics.NewCounter("add_counter", []string{"region"})
 	metrics.Start(wg)
 
 	wg.Add(1)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -14,7 +14,7 @@ func TestRegisterInvalidName(t *testing.T) {
 	assert.NotPanics(t, assert.PanicTestFunc(func() {
 		// Uncaught:
 		// Panic value:	panic: descriptor Desc{...} is invalid: "test.metric" is not a valid metric name [recovered]
-		m.RegisterCounter("test.metric", []string{"this", "that"})
+		m.NewCounter("test.metric", []string{"this", "that"})
 	}))
 	assert.Equal(t, 1, testutil.CollectAndCount(m.mPanicRecovery))
 }

--- a/register.go
+++ b/register.go
@@ -2,7 +2,7 @@ package apex
 
 import "github.com/prometheus/client_golang/prometheus"
 
-func (m *Metrics) RegisterCounter(name string, labels []string) {
+func (m *Metrics) NewCounter(name string, labels []string) {
 	n, err := m.nameBuilder(name)
 	if err != nil {
 		m.metrics[name] = m.mErrorInvalid
@@ -19,7 +19,7 @@ func (m *Metrics) RegisterCounter(name string, labels []string) {
 	}
 }
 
-func (m *Metrics) RegisterGauge(name string, labels []string) {
+func (m *Metrics) NewGauge(name string, labels []string) {
 	n, err := m.nameBuilder(name)
 	if err != nil {
 		m.metrics[name] = m.mErrorInvalid
@@ -36,7 +36,7 @@ func (m *Metrics) RegisterGauge(name string, labels []string) {
 	}
 }
 
-func (m *Metrics) RegisterSummary(name string, labels []string) {
+func (m *Metrics) NewSummary(name string, labels []string) {
 	n, err := m.nameBuilder(name)
 	if err != nil {
 		m.metrics[name] = m.mErrorInvalid
@@ -53,7 +53,7 @@ func (m *Metrics) RegisterSummary(name string, labels []string) {
 	}
 }
 
-func (m *Metrics) RegisterHistogram(name string, labels []string, buckets []float64) {
+func (m *Metrics) NewHistogram(name string, labels []string, buckets []float64) {
 	n, err := m.nameBuilder(name)
 	if err != nil {
 		m.metrics[name] = m.mErrorInvalid


### PR DESCRIPTION
Use the standard "New" prefix for creation and registration