### PR TITLE
Use apex package labels

### DIFF
--- a/apex.go
+++ b/apex.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"ctx.sh/apex/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -51,7 +50,7 @@ func (m *Metrics) Start() error {
 func (m *Metrics) CounterInc(name string, labels Labels) {
 	defer m.recover(name, "CounterInc")
 
-	if err := m.counters.Inc(name, prometheus.Labels(labels)); err != nil {
+	if err := m.counters.Inc(name, labels); err != nil {
 		m.emitError(err, name, "CounterInc")
 	}
 }
@@ -59,7 +58,7 @@ func (m *Metrics) CounterInc(name string, labels Labels) {
 func (m *Metrics) CounterAdd(name string, value float64, labels Labels) {
 	defer m.recover(name, "CounterAdd")
 
-	if err := m.counters.Add(name, value, prometheus.Labels(labels)); err != nil {
+	if err := m.counters.Add(name, value, labels); err != nil {
 		m.emitError(err, name, "CounterAdd")
 	}
 }
@@ -67,7 +66,7 @@ func (m *Metrics) CounterAdd(name string, value float64, labels Labels) {
 func (m *Metrics) GaugeSet(name string, value float64, labels Labels) {
 	defer m.recover(name, "GaugeSet")
 
-	if err := m.gauges.Set(name, value, prometheus.Labels(labels)); err != nil {
+	if err := m.gauges.Set(name, value, labels); err != nil {
 		m.emitError(err, name, "GaugeSet")
 	}
 }
@@ -75,7 +74,7 @@ func (m *Metrics) GaugeSet(name string, value float64, labels Labels) {
 func (m *Metrics) GaugeInc(name string, labels Labels) {
 	defer m.recover(name, "GaugeInc")
 
-	if err := m.gauges.Inc(name, prometheus.Labels(labels)); err != nil {
+	if err := m.gauges.Inc(name, labels); err != nil {
 		m.emitError(err, name, "GaugeInc")
 	}
 }
@@ -83,7 +82,7 @@ func (m *Metrics) GaugeInc(name string, labels Labels) {
 func (m *Metrics) GaugeDec(name string, labels Labels) {
 	defer m.recover(name, "GaugeDec")
 
-	if err := m.gauges.Dec(name, prometheus.Labels(labels)); err != nil {
+	if err := m.gauges.Dec(name, labels); err != nil {
 		m.emitError(err, name, "GaugeDec")
 	}
 }
@@ -91,7 +90,7 @@ func (m *Metrics) GaugeDec(name string, labels Labels) {
 func (m *Metrics) GaugeAdd(name string, value float64, labels Labels) {
 	defer m.recover(name, "GaugeAdd")
 
-	if err := m.gauges.Add(name, value, prometheus.Labels(labels)); err != nil {
+	if err := m.gauges.Add(name, value, labels); err != nil {
 		m.emitError(err, name, "GaugeAdd")
 	}
 }
@@ -99,7 +98,7 @@ func (m *Metrics) GaugeAdd(name string, value float64, labels Labels) {
 func (m *Metrics) GaugeSub(name string, value float64, labels Labels) {
 	defer m.recover(name, "GaugeSub")
 
-	if err := m.gauges.Sub(name, value, prometheus.Labels(labels)); err != nil {
+	if err := m.gauges.Sub(name, value, labels); err != nil {
 		m.emitError(err, name, "GaugeSub")
 	}
 }
@@ -107,7 +106,7 @@ func (m *Metrics) GaugeSub(name string, value float64, labels Labels) {
 func (m *Metrics) HistogramObserve(name string, value float64, labels Labels, opts HistogramOpts) {
 	defer m.recover(name, "HistogramObserve")
 
-	if err := m.histograms.Observe(name, value, prometheus.Labels(labels), opts); err != nil {
+	if err := m.histograms.Observe(name, value, labels, opts); err != nil {
 		m.emitError(err, name, "HistogramObserve")
 	}
 }
@@ -115,7 +114,7 @@ func (m *Metrics) HistogramObserve(name string, value float64, labels Labels, op
 func (m *Metrics) HistogramTimer(name string, labels Labels, opts HistogramOpts) *Timer {
 	defer m.recover(name, "HistogramTimers")
 
-	timer, err := m.histograms.Timer(name, prometheus.Labels(labels), opts)
+	timer, err := m.histograms.Timer(name, labels, opts)
 	if err != nil {
 		m.emitError(err, name, "HistogramTimer")
 	}
@@ -125,7 +124,7 @@ func (m *Metrics) HistogramTimer(name string, labels Labels, opts HistogramOpts)
 func (m *Metrics) SummaryObserve(name string, value float64, labels Labels, opts SummaryOpts) {
 	defer m.recover(name, "SummaryObserve")
 
-	if err := m.summaries.Observe(name, value, prometheus.Labels(labels), opts); err != nil {
+	if err := m.summaries.Observe(name, value, labels, opts); err != nil {
 		m.emitError(err, name, "SummaryObserve")
 	}
 }
@@ -133,7 +132,7 @@ func (m *Metrics) SummaryObserve(name string, value float64, labels Labels, opts
 func (m *Metrics) SummaryTimer(name string, labels Labels, opts SummaryOpts) *Timer {
 	defer m.recover(name, "SummaryTimers")
 
-	timer, err := m.summaries.Timer(name, prometheus.Labels(labels), opts)
+	timer, err := m.summaries.Timer(name, labels, opts)
 	if err != nil {
 		m.emitError(err, name, "counter_inc")
 	}

--- a/apex_test.go
+++ b/apex_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"ctx.sh/apex/utils"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,25 +19,25 @@ func TestMetricsCounter(t *testing.T) {
 		Separator: ':',
 	})
 
-	fullName, _ := utils.NameBuilder("apex", "example", name, ':')
+	fullName, _ := NameBuilder("apex", "example", name, ':')
 
 	elem := m.counters
-	metric, _ := elem.Get(name, prometheus.Labels(labels))
+	metric, _ := elem.Get(name, Labels(labels))
 
 	m.CounterInc(name, labels)
-	expected := utils.BuildProm(fullName, help, "counter", labels, 1)
+	expected := BuildProm(fullName, help, "counter", labels, 1)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	m.CounterAdd(name, 5.0, labels)
-	expected = utils.BuildProm(fullName, help, "counter", labels, 6)
+	expected = BuildProm(fullName, help, "counter", labels, 6)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	m.CounterInc(name, labels)
-	expected = utils.BuildProm(fullName, help, "counter", labels, 7)
+	expected = BuildProm(fullName, help, "counter", labels, 7)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	m.CounterAdd(name, 6.0, labels)
-	expected = utils.BuildProm(fullName, help, "counter", labels, 13)
+	expected = BuildProm(fullName, help, "counter", labels, 13)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 }
 
@@ -54,32 +52,32 @@ func TestMetricsGauge(t *testing.T) {
 		Separator: ':',
 	})
 
-	fullName, _ := utils.NameBuilder("apex", "example", name, ':')
+	fullName, _ := NameBuilder("apex", "example", name, ':')
 
 	elem := m.gauges
-	metric, _ := elem.Get(name, prometheus.Labels(labels))
+	metric, _ := elem.Get(name, Labels(labels))
 
 	m.GaugeSet(name, 100, labels)
-	expected := utils.BuildProm(fullName, help, "gauge", labels, 100)
+	expected := BuildProm(fullName, help, "gauge", labels, 100)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	m.GaugeInc(name, labels)
-	expected = utils.BuildProm(fullName, help, "gauge", labels, 101)
+	expected = BuildProm(fullName, help, "gauge", labels, 101)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	m.GaugeInc(name, labels)
-	expected = utils.BuildProm(fullName, help, "gauge", labels, 102)
+	expected = BuildProm(fullName, help, "gauge", labels, 102)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	m.GaugeDec(name, labels)
-	expected = utils.BuildProm(fullName, help, "gauge", labels, 101)
+	expected = BuildProm(fullName, help, "gauge", labels, 101)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	m.GaugeAdd(name, 9, labels)
-	expected = utils.BuildProm(fullName, help, "gauge", labels, 110)
+	expected = BuildProm(fullName, help, "gauge", labels, 110)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	m.GaugeSub(name, 109, labels)
-	expected = utils.BuildProm(fullName, help, "gauge", labels, 1)
+	expected = BuildProm(fullName, help, "gauge", labels, 1)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 }

--- a/counters.go
+++ b/counters.go
@@ -1,7 +1,6 @@
 package apex
 
 import (
-	"ctx.sh/apex/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -21,16 +20,16 @@ func NewCounters(ns string, sub string, sep rune) *Counters {
 	}
 }
 
-func (c *Counters) Get(name string, labels prometheus.Labels) (*prometheus.CounterVec, error) {
+func (c *Counters) Get(name string, labels Labels) (*prometheus.CounterVec, error) {
 	if metric, can := c.metrics[name]; can {
 		return metric, nil
 	}
 
-	return c.Register(name, utils.LabelKeys(labels))
+	return c.Register(name, LabelKeys(labels))
 }
 
 func (c *Counters) Register(name string, labels []string) (*prometheus.CounterVec, error) {
-	n, err := utils.NameBuilder(c.namespace, c.subsystem, name, c.separator)
+	n, err := NameBuilder(c.namespace, c.subsystem, name, c.separator)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +39,7 @@ func (c *Counters) Register(name string, labels []string) (*prometheus.CounterVe
 		Help: "created automagically by apex",
 	}, labels)
 
-	if err := utils.Register(counter); err != nil {
+	if err := Register(counter); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +47,7 @@ func (c *Counters) Register(name string, labels []string) (*prometheus.CounterVe
 	return counter, nil
 }
 
-func (c *Counters) Inc(name string, labels prometheus.Labels) error {
+func (c *Counters) Inc(name string, labels Labels) error {
 	counter, err := c.Get(name, labels)
 	if err != nil {
 		return err
@@ -58,7 +57,7 @@ func (c *Counters) Inc(name string, labels prometheus.Labels) error {
 	return nil
 }
 
-func (c *Counters) Add(name string, value float64, labels prometheus.Labels) error {
+func (c *Counters) Add(name string, value float64, labels Labels) error {
 	counter, err := c.Get(name, labels)
 	if err != nil {
 		return err

--- a/counters_test.go
+++ b/counters_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"ctx.sh/apex/utils"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,28 +11,28 @@ import (
 func TestCounter(t *testing.T) {
 	name := "test_counter"
 	help := "created automagically by apex"
-	labels := prometheus.Labels{"this": "one"}
+	labels := Labels{"this": "one"}
 
 	c := NewCounters("", "", ':')
 	metric, _ := c.Get(name, labels)
 
 	err := c.Add(name, 5.0, labels)
-	expected := utils.BuildProm(name, help, "counter", labels, 5)
+	expected := BuildProm(name, help, "counter", labels, 5)
 	assert.NoError(t, err)
-	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
+	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	err = c.Inc(name, labels)
-	expected = utils.BuildProm(name, help, "counter", labels, 6)
+	expected = BuildProm(name, help, "counter", labels, 6)
 	assert.NoError(t, err)
-	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
+	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	err = c.Add(name, 6.0, labels)
-	expected = utils.BuildProm(name, help, "counter", labels, 12)
+	expected = BuildProm(name, help, "counter", labels, 12)
 	assert.NoError(t, err)
-	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
+	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 
 	err = c.Inc(name, labels)
-	expected = utils.BuildProm(name, help, "counter", labels, 13)
+	expected = BuildProm(name, help, "counter", labels, 13)
 	assert.NoError(t, err)
-	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
+	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)))
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -17,7 +17,8 @@ var (
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		AgeBuckets: 5,
 	}
-	labels = apex.Labels{"region": "us-east-1"}
+	labels      = apex.Labels{"region": "us-east-1"}
+	otherLabels = apex.Labels{"func": "runOnce", "region": "us-east-1"}
 )
 
 func random(min int, max int) float64 {
@@ -36,13 +37,16 @@ func runOnce(m *apex.Metrics) {
 	m.CounterInc("test_counter", labels)
 	m.CounterAdd("test_counter", 5.0, labels)
 
+	// If different labels are used, a new measurement is created
+	m.CounterInc("test_counter", otherLabels)
+
 	// Gauge functions
 	m.GaugeInc("test_gauge", labels)
 	m.GaugeSet("test_gauge", random(1, 100), labels)
 	m.GaugeAdd("test_gauge", 2.0, labels)
 	m.GaugeSub("test_gauge", 1.0, labels)
 
-	// Summary observer
+	// Summary observation
 	m.SummaryObserve("test_summary", random(1, 10), labels, summaryOpts)
 
 	delay := time.Duration(random(500, 1500)) * time.Millisecond

--- a/gauges.go
+++ b/gauges.go
@@ -1,7 +1,6 @@
 package apex
 
 import (
-	"ctx.sh/apex/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -21,16 +20,16 @@ func NewGauges(ns string, sub string, sep rune) *Gauges {
 	}
 }
 
-func (g *Gauges) Get(name string, labels prometheus.Labels) (*prometheus.GaugeVec, error) {
+func (g *Gauges) Get(name string, labels Labels) (*prometheus.GaugeVec, error) {
 	if metric, can := g.metrics[name]; can {
 		return metric, nil
 	}
 
-	return g.Register(name, utils.LabelKeys(labels))
+	return g.Register(name, LabelKeys(labels))
 }
 
 func (g *Gauges) Register(name string, labels []string) (*prometheus.GaugeVec, error) {
-	n, err := utils.NameBuilder(g.namespace, g.subsystem, name, g.separator)
+	n, err := NameBuilder(g.namespace, g.subsystem, name, g.separator)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +39,7 @@ func (g *Gauges) Register(name string, labels []string) (*prometheus.GaugeVec, e
 		Help: "created automagically by apex",
 	}, labels)
 
-	if err := utils.Register(gauge); err != nil {
+	if err := Register(gauge); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +47,7 @@ func (g *Gauges) Register(name string, labels []string) (*prometheus.GaugeVec, e
 	return gauge, nil
 }
 
-func (g *Gauges) Set(name string, value float64, labels prometheus.Labels) error {
+func (g *Gauges) Set(name string, value float64, labels Labels) error {
 	gauge, err := g.Get(name, labels)
 	if err != nil {
 		return err
@@ -58,7 +57,7 @@ func (g *Gauges) Set(name string, value float64, labels prometheus.Labels) error
 	return nil
 }
 
-func (g *Gauges) Inc(name string, labels prometheus.Labels) error {
+func (g *Gauges) Inc(name string, labels Labels) error {
 	gauge, err := g.Get(name, labels)
 	if err != nil {
 		return err
@@ -68,7 +67,7 @@ func (g *Gauges) Inc(name string, labels prometheus.Labels) error {
 	return nil
 }
 
-func (g *Gauges) Dec(name string, labels prometheus.Labels) error {
+func (g *Gauges) Dec(name string, labels Labels) error {
 	gauge, err := g.Get(name, labels)
 	if err != nil {
 		return err
@@ -78,7 +77,7 @@ func (g *Gauges) Dec(name string, labels prometheus.Labels) error {
 	return nil
 }
 
-func (g *Gauges) Add(name string, value float64, labels prometheus.Labels) error {
+func (g *Gauges) Add(name string, value float64, labels Labels) error {
 	gauge, err := g.Get(name, labels)
 	if err != nil {
 		return err
@@ -88,7 +87,7 @@ func (g *Gauges) Add(name string, value float64, labels prometheus.Labels) error
 	return nil
 }
 
-func (g *Gauges) Sub(name string, value float64, labels prometheus.Labels) error {
+func (g *Gauges) Sub(name string, value float64, labels Labels) error {
 	gauge, err := g.Get(name, labels)
 	if err != nil {
 		return err

--- a/gauges_test.go
+++ b/gauges_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"ctx.sh/apex/utils"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,38 +11,38 @@ import (
 func TestGauge(t *testing.T) {
 	name := "test_metric"
 	help := "created automagically by apex"
-	labels := prometheus.Labels{"this": "one"}
+	labels := Labels{"this": "one"}
 
 	m := NewGauges("", "", ':')
 	metric, _ := m.Get(name, labels)
 
 	err := m.Set(name, 100, labels)
-	expected := utils.BuildProm(name, help, "gauge", labels, 100)
+	expected := BuildProm(name, help, "gauge", labels, 100)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	err = m.Inc(name, labels)
-	expected = utils.BuildProm(name, help, "gauge", labels, 101)
+	expected = BuildProm(name, help, "gauge", labels, 101)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	err = m.Inc(name, labels)
-	expected = utils.BuildProm(name, help, "gauge", labels, 102)
+	expected = BuildProm(name, help, "gauge", labels, 102)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	err = m.Dec(name, labels)
-	expected = utils.BuildProm(name, help, "gauge", labels, 101)
+	expected = BuildProm(name, help, "gauge", labels, 101)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	err = m.Add(name, 9, labels)
-	expected = utils.BuildProm(name, help, "gauge", labels, 110)
+	expected = BuildProm(name, help, "gauge", labels, 110)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 
 	err = m.Sub(name, 109, labels)
-	expected = utils.BuildProm(name, help, "gauge", labels, 1)
+	expected = BuildProm(name, help, "gauge", labels, 1)
 	assert.NoError(t, err)
 	assert.NoError(t, testutil.CollectAndCompare(metric, strings.NewReader(expected)), "name")
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,4 +1,4 @@
-package utils
+package apex
 
 import (
 	"strconv"

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,4 +1,4 @@
-package utils
+package apex
 
 import (
 	"testing"

--- a/histograms.go
+++ b/histograms.go
@@ -1,7 +1,6 @@
 package apex
 
 import (
-	"ctx.sh/apex/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -25,16 +24,16 @@ func NewHistograms(ns string, sub string, sep rune) *Histograms {
 	}
 }
 
-func (h *Histograms) Get(name string, labels prometheus.Labels, opts HistogramOpts) (*prometheus.HistogramVec, error) {
+func (h *Histograms) Get(name string, labels Labels, opts HistogramOpts) (*prometheus.HistogramVec, error) {
 	if metric, can := h.metrics[name]; can {
 		return metric, nil
 	}
 
-	return h.Register(name, utils.LabelKeys(labels), opts)
+	return h.Register(name, LabelKeys(labels), opts)
 }
 
 func (h *Histograms) Register(name string, labels []string, opts HistogramOpts) (*prometheus.HistogramVec, error) {
-	n, err := utils.NameBuilder(h.namespace, h.subsystem, name, h.separator)
+	n, err := NameBuilder(h.namespace, h.subsystem, name, h.separator)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +48,7 @@ func (h *Histograms) Register(name string, labels []string, opts HistogramOpts) 
 		Buckets: opts.Buckets,
 	}, labels)
 
-	if err := utils.Register(histogram); err != nil {
+	if err := Register(histogram); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +56,7 @@ func (h *Histograms) Register(name string, labels []string, opts HistogramOpts) 
 	return histogram, nil
 }
 
-func (h *Histograms) Observe(name string, value float64, labels prometheus.Labels, opts HistogramOpts) error {
+func (h *Histograms) Observe(name string, value float64, labels Labels, opts HistogramOpts) error {
 	histogram, err := h.Get(name, labels, opts)
 	if err != nil {
 		return err
@@ -66,7 +65,7 @@ func (h *Histograms) Observe(name string, value float64, labels prometheus.Label
 	return nil
 }
 
-func (h *Histograms) Timer(name string, labels prometheus.Labels, opts HistogramOpts) (*Timer, error) {
+func (h *Histograms) Timer(name string, labels Labels, opts HistogramOpts) (*Timer, error) {
 	histogram, err := h.Get(name, labels, opts)
 	if err != nil {
 		return nil, err

--- a/summaries.go
+++ b/summaries.go
@@ -3,7 +3,6 @@ package apex
 import (
 	"time"
 
-	"ctx.sh/apex/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -35,16 +34,16 @@ func NewSummaries(ns string, sub string, sep rune) *Summaries {
 	}
 }
 
-func (s *Summaries) Get(name string, labels prometheus.Labels, opts SummaryOpts) (*prometheus.SummaryVec, error) {
+func (s *Summaries) Get(name string, labels Labels, opts SummaryOpts) (*prometheus.SummaryVec, error) {
 	if metric, can := s.metrics[name]; can {
 		return metric, nil
 	}
 
-	return s.Register(name, utils.LabelKeys(labels), opts)
+	return s.Register(name, LabelKeys(labels), opts)
 }
 
 func (s *Summaries) Register(name string, labels []string, opts SummaryOpts) (*prometheus.SummaryVec, error) {
-	n, err := utils.NameBuilder(s.namespace, s.subsystem, name, s.separator)
+	n, err := NameBuilder(s.namespace, s.subsystem, name, s.separator)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +68,7 @@ func (s *Summaries) Register(name string, labels []string, opts SummaryOpts) (*p
 		AgeBuckets: opts.AgeBuckets,
 	}, labels)
 
-	if err := utils.Register(summary); err != nil {
+	if err := Register(summary); err != nil {
 		return nil, err
 	}
 
@@ -77,7 +76,7 @@ func (s *Summaries) Register(name string, labels []string, opts SummaryOpts) (*p
 	return summary, nil
 }
 
-func (s *Summaries) Observe(name string, value float64, labels prometheus.Labels, opts SummaryOpts) error {
+func (s *Summaries) Observe(name string, value float64, labels Labels, opts SummaryOpts) error {
 	summary, err := s.Get(name, labels, opts)
 	if err != nil {
 		return err
@@ -86,7 +85,7 @@ func (s *Summaries) Observe(name string, value float64, labels prometheus.Labels
 	return nil
 }
 
-func (s *Summaries) Timer(name string, labels prometheus.Labels, opts SummaryOpts) (*Timer, error) {
+func (s *Summaries) Timer(name string, labels Labels, opts SummaryOpts) (*Timer, error) {
 	summary, err := s.Get(name, labels, opts)
 	if err != nil {
 		return nil, err

--- a/timer.go
+++ b/timer.go
@@ -8,13 +8,13 @@ type Timer struct {
 	timer *prometheus.Timer
 }
 
-func NewTimer(collector prometheus.Collector, labels prometheus.Labels) *Timer {
+func NewTimer(collector prometheus.Collector, labels Labels) *Timer {
 	t := &Timer{}
 	switch metric := collector.(type) {
 	case *prometheus.HistogramVec:
-		t.timer = prometheus.NewTimer(metric.With(labels))
+		t.timer = prometheus.NewTimer(metric.With(prometheus.Labels(labels)))
 	case *prometheus.SummaryVec:
-		t.timer = prometheus.NewTimer(metric.With(labels))
+		t.timer = prometheus.NewTimer(metric.With(prometheus.Labels(labels)))
 	default:
 		t.timer = nil
 	}

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package utils
+package apex
 
 import (
 	"strings"
@@ -27,7 +27,7 @@ func NameBuilder(ns string, sub string, name string, sep rune) (string, error) {
 	return builder.String(), nil
 }
 
-func LabelKeys(labels prometheus.Labels) []string {
+func LabelKeys(labels Labels) []string {
 	keys := make([]string, 0)
 	for k := range labels {
 		keys = append(keys, k)

--- a/util_test.go
+++ b/util_test.go
@@ -1,11 +1,10 @@
-package utils
+package apex
 
 import (
 	"sort"
 	"testing"
 
 	"ctx.sh/apex/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +36,7 @@ func TestNameBuilder(t *testing.T) {
 }
 
 func TestLabelKeys(t *testing.T) {
-	retval := LabelKeys(prometheus.Labels{
+	retval := LabelKeys(Labels{
 		"one": "1",
 		"two": "2",
 	})


### PR DESCRIPTION
Prefers the apex defined label type over the prometheus label type until
it needs to be casted when calling the prometheus functions.