### PR TITLE
fix: ensure panic if PanicOnError is true

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -196,7 +196,9 @@ func (m *Metrics) emitError(err error, name string, fn string) {
 }
 
 func (m *Metrics) recover(name string, fn string) {
-	if r := recover(); r != nil && !m.opts.PanicOnError {
-		m.errors.PanicRecovery(name, fn)
+	if !m.opts.PanicOnError {
+		if r := recover(); r != nil {
+			m.errors.PanicRecovery(name, fn)
+		}
 	}
 }


### PR DESCRIPTION
Only attempt the recovery if PanicOnError is false.  There was a bug mostly due to my misunderstanding of what was going on that was causing the panic to be recovered in the conditional, so no matter what panics were ignored.