### PR TITLE
feat: allow subsystems as array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,22 @@ metrics := apex.New(apex.MetricsOpts{
 })
 ```
 
+Subsystems represented as an array of strings are also support to give additional flexibility in defining other groupings beneath the subsystem.
+
+```golang
+metrics := apex.New(apex.MetricsOpts{
+  Namespace:    "apex",
+  Subsystem:    []string{"example", "internal"},
+  Separator:    ':',
+  PanicOnError: false,
+})
+```
+
 | Option | Default | Description |
 |--------|---------|-------------|
 | BindAddr | `0.0.0.0` | The address the promethus collector will listen on for connections |
 | Namespace | empty | The prefix for a metric |
-| Subsystem | empty | A string that represents the subsystem.  This value is joined to the namespace with the defined seperator |
+| Subsystem | empty | A string or array of strings that represent the subsystem(s).  The value is joined to the namespace with the defined seperator.  If an array of strings is given, the strings are joined with the seperator. |
 | Separator | `_` | The seperator that will be used to join the metric name components. |
 | Path | `/metrics` | The path used by the HTTP server |
 | Port | `9000` | The port used by the HTTP server |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ metrics := apex.New(apex.MetricsOpts{
 })
 ```
 
-Subsystems represented as an array of strings are also support to give additional flexibility in defining other groupings beneath the subsystem.
+Subsystems can also be defined as an array of strings to give users the flexibility to add additional groupings within a more complex environment.
 
 ```golang
 metrics := apex.New(apex.MetricsOpts{

--- a/counters.go
+++ b/counters.go
@@ -25,11 +25,11 @@ import (
 type Counters struct {
 	metrics   map[string]*prometheus.CounterVec
 	namespace string
-	subsystem string
+	subsystem interface{}
 	separator rune
 }
 
-func NewCounters(ns string, sub string, sep rune) *Counters {
+func NewCounters(ns string, sub interface{}, sep rune) *Counters {
 	return &Counters{
 		metrics:   make(map[string]*prometheus.CounterVec),
 		namespace: ns,

--- a/errors.go
+++ b/errors.go
@@ -43,7 +43,7 @@ type ApexInternalErrorMetrics struct {
 	errAlreadyRegistered  *prometheus.CounterVec
 }
 
-func NewApexInternalErrorMetrics(ns string, sub string, sep rune) *ApexInternalErrorMetrics {
+func NewApexInternalErrorMetrics(ns string, sub interface{}, sep rune) *ApexInternalErrorMetrics {
 	var builder strings.Builder
 
 	if ns != "" {
@@ -51,8 +51,9 @@ func NewApexInternalErrorMetrics(ns string, sub string, sep rune) *ApexInternalE
 		builder.WriteRune(sep)
 	}
 
-	if sub != "" {
-		builder.WriteString(sub)
+	ss := subSystemToString(sub, sep)
+	if ss != "" {
+		builder.WriteString(ss)
 		builder.WriteRune(sep)
 	}
 

--- a/gauges.go
+++ b/gauges.go
@@ -25,11 +25,11 @@ import (
 type Gauges struct {
 	metrics   map[string]*prometheus.GaugeVec
 	namespace string
-	subsystem string
+	subsystem interface{}
 	separator rune
 }
 
-func NewGauges(ns string, sub string, sep rune) *Gauges {
+func NewGauges(ns string, sub interface{}, sep rune) *Gauges {
 	return &Gauges{
 		metrics:   make(map[string]*prometheus.GaugeVec),
 		namespace: ns,

--- a/histograms.go
+++ b/histograms.go
@@ -29,11 +29,11 @@ type HistogramOpts struct {
 type Histograms struct {
 	metrics   map[string]*prometheus.HistogramVec
 	namespace string
-	subsystem string
+	subsystem interface{}
 	separator rune
 }
 
-func NewHistograms(ns string, sub string, sep rune) *Histograms {
+func NewHistograms(ns string, sub interface{}, sep rune) *Histograms {
 	return &Histograms{
 		metrics:   make(map[string]*prometheus.HistogramVec),
 		namespace: ns,

--- a/metrics.go
+++ b/metrics.go
@@ -28,7 +28,7 @@ import (
 type MetricsOpts struct {
 	BindAddr     string
 	Namespace    string
-	Subsystem    string
+	Subsystem    interface{}
 	Path         string
 	Port         int
 	Separator    rune

--- a/summaries.go
+++ b/summaries.go
@@ -39,11 +39,11 @@ type SummaryOpts struct {
 type Summaries struct {
 	metrics   map[string]*prometheus.SummaryVec
 	namespace string
-	subsystem string
+	subsystem interface{}
 	separator rune
 }
 
-func NewSummaries(ns string, sub string, sep rune) *Summaries {
+func NewSummaries(ns string, sub interface{}, sep rune) *Summaries {
 	return &Summaries{
 		metrics:   make(map[string]*prometheus.SummaryVec),
 		namespace: ns,

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NameBuilder(ns string, sub string, name string, sep rune) (string, error) {
+func NameBuilder(ns string, sub interface{}, name string, sep rune) (string, error) {
 	var builder strings.Builder
 
 	if ns != "" {
@@ -32,8 +32,9 @@ func NameBuilder(ns string, sub string, name string, sep rune) (string, error) {
 		builder.WriteRune(sep)
 	}
 
-	if sub != "" {
-		builder.WriteString(sub)
+	ss := subSystemToString(sub, sep)
+	if ss != "" {
+		builder.WriteString(ss)
 		builder.WriteRune(sep)
 	}
 
@@ -53,4 +54,15 @@ func Register(metric prometheus.Collector) error {
 		}
 	}
 	return nil
+}
+
+func subSystemToString(sub interface{}, sep rune) string {
+	switch s := sub.(type) {
+	case string:
+		return s
+	case []string:
+		return strings.Join(s, string(sep))
+	}
+
+	panic("unsupported subsystem type")
 }

--- a/util_test.go
+++ b/util_test.go
@@ -43,3 +43,22 @@ func TestLabelKeys(t *testing.T) {
 	expected := []string{"one", "two"}
 	assert.Equal(t, expected, retval)
 }
+
+func TestSubsystemToString(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected string
+	}{
+		{"", ""},
+		{[]string{}, ""},
+		{[]string{""}, ""},
+		{"one", "one"},
+		{[]string{"one"}, "one"},
+		{[]string{"one_two"}, "one_two"},
+	}
+
+	for i, tt := range tests {
+		actual := subSystemToString(tt.input, '_')
+		assert.Equal(t, tt.expected, actual, "test[%d]: %v", i, tt.input)
+	}
+}


### PR DESCRIPTION
Subsystems can now be defined as a string or an array of strings to give users the flexibility to add additional groupings within a more complex environment.

```golang
metrics := apex.New(apex.MetricsOpts{
  Namespace:    "apex",
  Subsystem:    []string{"example", "internal"},
  Separator:    ':',
  PanicOnError: true,
})
```